### PR TITLE
Refine memory retrieval logic and enhance historical message parsing

### DIFF
--- a/.agentforge/prompts/TrinityAgents/ThoughtAgent.yaml
+++ b/.agentforge/prompts/TrinityAgents/ThoughtAgent.yaml
@@ -73,6 +73,7 @@ prompts:
       ## Chat History
       The following is the relevant chat history:
       {chat_history}
+
     Chat messages: |+
       ## New User Message
       The user has said:

--- a/Utilities/Memory.py
+++ b/Utilities/Memory.py
@@ -138,11 +138,7 @@ class Memory:
             history = self.memory.query_storage(collection_name=collection_name, query=query, num_results=query_size)
             formatted_history = self.parser.format_user_specific_history_entries(history)
         else:
-            qsize = min(collection_size, query_size)  # Determine the number of messages to retrieve
-            start_id = collection_size - qsize + 1  # Calculate the starting 'id' to get the last 'qsize' messages
-            filters = {"id": {"$gte": start_id}}  # Retrieve messages with 'id' greater than or equal to 'start_id'
-
-            history = self.memory.load_collection(collection_name=collection_name, where=filters)
+            history = self.memory.get_last_x_entries(collection_name=collection_name, x=query_size)
             formatted_history = self.parser.format_general_history_entries(history)
 
 

--- a/Utilities/Parsers.py
+++ b/Utilities/Parsers.py
@@ -184,7 +184,7 @@ class MessageParser:
         channel = ''
 
         # Create a list of tuples (index, id) and sort it by id
-        sorted_indices = sorted(enumerate(history.get('ids', [])), key=lambda x: x[1])
+        sorted_indices = sorted(enumerate(history.get('ids', [])), key=lambda x: int(x[1]))
 
         for index, _ in sorted_indices:
             metadata = history['metadatas'][index]
@@ -198,7 +198,7 @@ class MessageParser:
 
             excluded_metadata = [
                 "User", "id", "Response", "Reason", "Emotion", "InnerThought",
-                "Channel", "unix_timestamp", "Categories"
+                "Channel", "unix_timestamp", "Categories", "Respondent"
             ]
 
             for key, value in metadata.items():


### PR DESCRIPTION
Simplifies the retrieval of chat history by utilizing a dedicated helper method for fetching the most recent entries. Improves message ordering accuracy by enforcing numerical sorting on string-based IDs and refines metadata formatting by excluding the "Respondent" field from the output.